### PR TITLE
Resolves drop-down scoring issue

### DIFF
--- a/src/player.coffee
+++ b/src/player.coffee
@@ -56,8 +56,8 @@ SurveyWidget.controller 'SurveyWidgetEngineCtrl', ['$scope', '$mdToast', ($scope
 	$scope.isIncomplete = (index) ->
 		$scope.responses[index] == undefined
 
-	$scope.dropDownAnswer = (answerString) ->
-		if answerString then return answerString
+	$scope.dropDownAnswer = (questionIndex, answerIndex) ->
+		if answerIndex then return $scope.qset.items[questionIndex].answers[answerIndex].text
 		return 'Select Answer'
 
 	$scope.updateCompleted = ->

--- a/src/player.html
+++ b/src/player.html
@@ -64,10 +64,10 @@
 										ng-model="responses[$index]"
 										aria-label="Answer"
 										ng-change="updateCompleted()"
-										md-selected-text="dropDownAnswer(responses[$index])">
+										md-selected-text="dropDownAnswer($index, responses[$index])">
 										<md-option class="dropdown-answer-element"
 											ng-repeat="answer in question.answers"
-											ng-value="answer.text">
+											value="{{$index}}">
 												<span class="answer-text">
 													{{answer.text}}
 												</span>


### PR DESCRIPTION
The value for the `<option>` tags inside the drop-down `<select>` was `answer.text`, but instead of providing the answer text, the other MC options are using the index of the answer to locate the answer text from the qset. Updated the values to be in-line with this behavior.