### PR TITLE
Fix sequence items not appearing correctly in IE11

### DIFF
--- a/src/creator.html
+++ b/src/creator.html
@@ -274,7 +274,10 @@
 								layout-align="start start"
 								class="sequence-choice drag-choice"
 								ng-show="card.questionType == sequence">
-								<div layout="column" sv-root sv-part="card.answers">
+								<div class='sequence-item-container'
+									layout="column"
+									sv-root
+									sv-part="card.answers">
 									<div layout="row">
 										<md-checkbox
 											aria-label="Randomize Order"

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -191,3 +191,7 @@
 		min-width: 30px;
 	}
 }
+
+.sequence-item-container.layout-column {
+  display: block;
+}

--- a/src/player.html
+++ b/src/player.html
@@ -125,7 +125,8 @@
 							layout-align="start start"
 							class="drag-choice"
 							ng-if="question.options.displayStyle == sequence">
-							<div layout="column"
+							<div class="sequence-item-container"
+								layout="column"
 								sv-root
 								sv-on-sort="markSequenceComplete($parent.$index)"
 								sv-part="question.answers"

--- a/src/player.scss
+++ b/src/player.scss
@@ -151,6 +151,10 @@ button.info-tooltip-button {
 	flex-wrap: wrap;
 }
 
+.sequence-item-container.layout-column {
+  display: block;
+}
+
 .sequence-item {
 	display: flex;
 	z-index: 1;


### PR DESCRIPTION
Closes #29.

Adjusting the display rule for sequence item parent containers from `flex` to `block` seems to make everything appear and still function correctly.