### PR TITLE
Redoes styling/DOM rules for sequence items.

### DIFF
--- a/src/player.html
+++ b/src/player.html
@@ -134,11 +134,9 @@
 								role="listbox">
 								<p class='instructions'>
 									<span>
-											Arrange the following sequence of items as desired.
-											Use the arrow buttons or click and drag the items to rearrange them.
-									</span>
-									<span>
-										You may also navigate through the list with the tab key and rearrange the items using the 'Up' or 'Down' arrow keys.
+										Arrange the following sequence.
+										Drag and drop, use the arrow buttons,
+										or navigate through the list with 'Tab' and rearrange using the 'Up' or 'Down' keys.
 									</span>
 								</p>
 								<div layout="row"
@@ -171,20 +169,25 @@
 											<md-tooltip md-direction="below">Drag to Reorder</md-tooltip>
 										</i>
 									</span>
-									<span aria-hidden="true"
-										class="reorder-controls">
-										<span class="move-arrow"
+									<span class="move-arrow"
+										aria-hidden="true"
+										tabindex="-1">
+										<i class="material-icons"
 											tabindex="-1"
 											ng-click="moveSequenceItemUp($parent.$index, $index)">
+											&#xE316;
 											<md-tooltip md-direction="below">Move Item Up</md-tooltip>
-											<i class="material-icons">&#xE316;</i>
-										</span>
-										<span class="move-arrow"
+										</i>
+									</span>
+									<span class="move-arrow"
+										aria-hidden="true"
+										tabindex="-1">
+										<i class="material-icons"
 											tabindex="-1"
 											ng-click="moveSequenceItemDown($parent.$index, $index)">
+											&#xE313;
 											<md-tooltip md-direction="below">Move Item Down</md-tooltip>
-											<i class="material-icons">&#xE313;</i>
-										</span>
+										</i>
 									</span>
 									<span class='sequence-item-text'>
 										{{item.text}}

--- a/src/player.scss
+++ b/src/player.scss
@@ -156,7 +156,7 @@ button.info-tooltip-button {
 		font-size: 18px;
 	}
 }
-.layout-row {
+.layout-row:not(.sequence-item) {
 	flex-wrap: wrap;
 }
 
@@ -166,6 +166,8 @@ button.info-tooltip-button {
 
 .sequence-item {
 	display: flex;
+	align-items: flex-start;
+	cursor: grab;
 	z-index: 1;
 	background-color: rgba(245, 245, 245, 0.8);
 	box-shadow: inset 0 -1px 0 0 rgba(100, 121, 143, 0.2);
@@ -185,41 +187,26 @@ button.info-tooltip-button {
 	}
 
 	.drag-handle {
-		cursor: grab;
 		i {
 			margin-top: 10px;
 			opacity: 0.5;
 			transition: opacity linear 0.25s, width linear 0.25s;
 		}
-		&.hidden {
-			pointer-events: none;
-
-			i {
-				opacity: 0;
-				width: 0;
-			}
-		}
 	}
 
-	.reorder-controls {
+	.move-arrow {
 		opacity: 0.5;
-		margin: auto 0;
+		margin: 0;
 		user-select: none;
-		transition: opacity linear 0.25s, width linear 0.25s;
-
-		&.hidden {
-			opacity: 0;
-			width: 0;
-			pointer-events: none;
-		}
-
-		.move-arrow {
-			cursor: pointer;
+		cursor: pointer;
+		i {
+			margin-top: 10px;
 		}
 	}
 
 	.sequence-item-text {
-		margin: auto 10px;
+		flex-basis: 100%;
+		margin: 10px;
 		padding: 0;
 		cursor: grab;
 		color: #202124;
@@ -229,8 +216,8 @@ button.info-tooltip-button {
 
 .instructions {
 	color: #575757;
-	font-size: 0.8em;
-	margin: 0 50px 5px 20px;
+	font-size: 0.9em;
+	margin: -5px 50px 10px 20px;
 	user-select: none;
 	outline: none;
 


### PR DESCRIPTION
Closes #32.

Adjusted styling and DOM for sequence items to handle large amounts of text properly. Reworked the instruction text.

Wrapping should work way better in all cases now.